### PR TITLE
Update travis config to allow greenkeeper to do its magic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,21 @@
 language: node_js
 sudo: false
 os:
-  - linux
-  - windows
+- linux
+- windows
 node_js:
-  - "6"
-  - "8"
-  - "9"
-  - "stable"
+- '6'
+- '8'
+- '9'
+- stable
 script:
-  - npm run lint
-  - npm run test:all
+- npm run lint
+- npm run test:all
 notifications:
   email: false
+before_install: yarn global add greenkeeper-lockfile@1
+before_script: greenkeeper-lockfile-update
+after_script: greenkeeper-lockfile-upload
+env:
+  global:
+    secure: SSs3jgNRFsfKMgbdzxUVJ0iJW2H7kJbEapo2vBbXIuMepsVh0PdGyxFk6Fuq1qKjpH2rkMnxGgC87oX4oMfS3cQsjaRTmsFRHbT/lWObim7C7NnwF3Kiu94OJd3E3mbA+LppA+3Gl8lQpDnaXFQc4OJl/s20EfMjycb6TtiWdXEaBXC7ERtSP9udmJhzo8LeFRUAPDglNhd2xwStJiheniRb3w6HV7Zsvu2Fwjio/uXttG7oea1VRjfZ7EaPXrCygVgaa12FiH1XYVeKgDurM4BHAIk83GKNPGqrlEIi8QnfwpZ2zaG9gW5KMtutzZwZ1QWfNJevN5QE6OU3hQPODrQyjeFNiWDJSwOtDvx0tn/A7eFRRs8klchuDKpFASqUIsS7Y/BVE07yIVCqExWYFG1Ur0yHouBuarmPef8nQ/+sk1NW6EZND++5ta35DfA//6+jnbEZCh/4DYUtfc1AczIOm2VIxQHye+cXqwEMr3uC/l1ONCV2j5/14MwNfv73v2MCPPPw3MvgIVADHv8dBqZT34GJwHjH3ASD98Gl/YM9D2k4gL1j1Uxq4jwMB6XJVWKwtxRqNMjsskuEHILlc/ECJi6BPo1c2AHjVCgmh77fvnskmTX+u18wfmCWmREjBX/Mc85SxX4c/AQMQXlUwf6Q0mLdYN7b2+lqFdcp+y0=


### PR DESCRIPTION
Update travis config to allow greenkeeper to do its magic

### Description
Used travis-ci's CLI to generate a token that should enable greenkeeper to update the `yarn.lock` file when updating dependencies.

### Motivation and Context
Since we use a `yarn.lock` file, we need special setup to enable greenkeeper to keep that in sync with our `package.json` deps.

### Checklist
<!--
  The purpose of this checklist is for you to not forget changes you most likely should do. Look 
  through the following points, and put an "x" in all the boxes that apply. If you're unsure about 
  any of these points, then we'd recommend you to read the README. If something still is unclear 
  then don't hesitate to ask. We're here to help!
-->
```
[ ] I have not included any built dist files (us maintainers do that prior to a new release)
[ ] I have added tests covering my changes
[x] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```


<!--
  Is there anything in this template you think is confusing, unclear, redundant or just simply bad?
  Please let us know either via creating an issue or creating a PR with changes to it.
-->
