### PR TITLE
Add a package size badge to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-datetime
 
-[![Build Status](https://secure.travis-ci.org/NateRadebaugh/react-datetime.svg)](https://travis-ci.org/NateRadebaugh/react-datetime) [![npm version](https://badge.fury.io/js/%40nateradebaugh%2Freact-datetime.svg)](https://badge.fury.io/js/%40nateradebaugh%2Freact-datetime) [![Greenkeeper badge](https://badges.greenkeeper.io/NateRadebaugh/react-datetime.svg)](https://greenkeeper.io/) [![Coverage Status](https://coveralls.io/repos/github/NateRadebaugh/react-datetime/badge.svg?branch=master)](https://coveralls.io/github/NateRadebaugh/react-datetime?branch=master)
+[![Build Status](https://secure.travis-ci.org/NateRadebaugh/react-datetime.svg)](https://travis-ci.org/NateRadebaugh/react-datetime) [![npm version](https://badge.fury.io/js/%40nateradebaugh%2Freact-datetime.svg)](https://badge.fury.io/js/%40nateradebaugh%2Freact-datetime) [![Greenkeeper badge](https://badges.greenkeeper.io/NateRadebaugh/react-datetime.svg)](https://greenkeeper.io/) [![Coverage Status](https://coveralls.io/repos/github/NateRadebaugh/react-datetime/badge.svg?branch=master)](https://coveralls.io/github/NateRadebaugh/react-datetime?branch=master) [![install size](https://packagephobia.now.sh/badge?p=@nateradebaugh/react-datetime)](https://packagephobia.now.sh/result?p=@nateradebaugh/react-datetime)
 
 A date and time picker in the same React.js component. It can be used as a datepicker, timepicker or both at the same time. It is **highly customizable** and it even allows to edit date's milliseconds.
 


### PR DESCRIPTION
### Description
Add a package size badge to the readme to be more transparent.

### Motivation and Context
I'd like to improve the size of the package/bundle. To be more transparent in this effort, adding a badge to indicate the current package size.

### Checklist
<!--
  The purpose of this checklist is for you to not forget changes you most likely should do. Look 
  through the following points, and put an "x" in all the boxes that apply. If you're unsure about 
  any of these points, then we'd recommend you to read the README. If something still is unclear 
  then don't hesitate to ask. We're here to help!
-->
```
[ ] I have not included any built dist files (us maintainers do that prior to a new release)
[ ] I have added tests covering my changes
[X] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```


<!--
  Is there anything in this template you think is confusing, unclear, redundant or just simply bad?
  Please let us know either via creating an issue or creating a PR with changes to it.
-->
