### PR TITLE
Apply yarn workaround for failing travis builds on windows machines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,9 @@ script:
 notifications:
   email: false
 before_install: yarn global add greenkeeper-lockfile@1
-before_script: greenkeeper-lockfile-update
+before_script:
+  - export PATH=$(yarn global bin):$PATH
+  - greenkeeper-lockfile-update
 after_script: greenkeeper-lockfile-upload
 after_success:
   - yarn report-coverage


### PR DESCRIPTION
### Description
Apply yarn workaround for failing travis builds on windows machines

### Motivation and Context
Something changed on travis that causes yarn to not be able to find some bin files on windows machines. A workaround has been used by other projects. For example:

https://github.com/atlassian/react-beautiful-dnd/pull/642/files
