### PR TITLE
 Switch popper to use window boundariesElement to work better

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nateradebaugh/react-datetime",
-  "version": "4.0.0-rc.5",
+  "version": "4.0.0-rc.6",
   "description": "A lightweight but complete datetime picker React.js component",
   "license": "MIT",
   "homepage": "https://github.com/NateRadebaugh/react-datetime",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "bundlesize": [
     {
       "path": "dist/index.js",
-      "maxSize": "4.22 kB"
+      "maxSize": "4.2 kB"
     }
   ],
   "keywords": [

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -664,6 +664,14 @@ class DateTime extends React.Component<DateTimeProps, DateTimeState> {
       ...this.props.inputProps
     };
 
+    const cal = (
+      <CalendarContainer
+        view={this.state.currentView}
+        viewProps={this.getComponentProps()}
+        onClickOutside={this.handleClickOutside}
+      />
+    );
+
     return (
       <div
         className={cc([
@@ -698,7 +706,7 @@ class DateTime extends React.Component<DateTimeProps, DateTimeState> {
                 modifiers={{
                   preventOverflow: {
                     enabled: true,
-                    boundariesElement: "viewport"
+                    boundariesElement: "window"
                   }
                 }}
               >
@@ -709,24 +717,14 @@ class DateTime extends React.Component<DateTimeProps, DateTimeState> {
                     data-placement={placement}
                     className="rdtPicker"
                   >
-                    <CalendarContainer
-                      view={this.state.currentView}
-                      viewProps={this.getComponentProps()}
-                      onClickOutside={this.handleClickOutside}
-                    />
+                    {cal}
                   </div>
                 )}
               </Popper>
             )}
           </Manager>
         ) : (
-          <div className="rdtPicker">
-            <CalendarContainer
-              view={this.state.currentView}
-              viewProps={this.getComponentProps()}
-              onClickOutside={this.handleClickOutside}
-            />
-          </div>
+          <div className="rdtPicker">{cal}</div>
         )}
       </div>
     );


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the *Title* above -->

### Description
Switch popper to use `"window"` `boundariesElement` to work better

### Motivation and Context
Popper.js is pretty great for what I use it for, but it doesn't really work in all the ways I want it to. `"window"` is a closer `boundariesElement` val to what I need here.

### Checklist
<!--
  The purpose of this checklist is for you to not forget changes you most likely should do. Look
  through the following points, and put an "x" in all the boxes that apply. If you're unsure about
  any of these points, then we'd recommend you to read the README. If something still is unclear
  then don't hesitate to ask. We're here to help!
-->
```
[ ] I have not included any built dist files (us maintainers do that prior to a new release)
[ ] I have added tests covering my changes
[x] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript type definitions accordingly
```


<!--
  Is there anything in this template you think is confusing, unclear, redundant or just simply bad?
  Please let us know either via creating an issue or creating a PR with changes to it.
-->
