### PR TITLE
Properly set correct month for local time zone.

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -564,7 +564,7 @@ class DateTime extends React.Component<DateTimeProps, DateTimeState> {
         const currentDate = selectedDate || viewDate;
         const date = parse(
           format(newDate, `YYYY${fmt.sel}`) +
-            format(currentDate, `${fmt.rest} HH:mm:ss.SSSZ`)
+            format(currentDate, `${fmt.rest} HH:mm:ss.SSS`)
         );
 
         const isControlled = this.props.value !== undefined;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the *Title* above -->

### Description
Selecting a single month to be displayed was showing the wrong month the first time. Turns out it was because of time zones. Updated to use local time zone instead.